### PR TITLE
Add warnings for GHC 9.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v1.2
       id: setup-haskell-cabal
       name: Setup Haskell
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
           - "8.6.5"
           - "8.8.4"
           - "8.10.7"
-          - "9.0.1"
+          - "9.0.2"
           - "9.2.1"
         exclude:
           - os: macOS-latest
             ghc: 9.2.1
           - os: macOS-latest
-            ghc: 9.0.1
+            ghc: 9.0.2
           - os: macOS-latest
             ghc: 8.8.4
           - os: macOS-latest
@@ -43,7 +43,7 @@ jobs:
           - os: windows-latest
             ghc: 9.2.1
           - os: windows-latest
-            ghc: 9.0.1
+            ghc: 9.0.2
           - os: windows-latest
             ghc: 8.8.4
           - os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [synchronize, opened, reopened]
   push:

--- a/co-log-core.cabal
+++ b/co-log-core.cabal
@@ -63,6 +63,11 @@ common common-options
     ghc-options:       -Wmissing-deriving-strategies
   if impl(ghc >= 8.10)
     ghc-options:       -Wunused-packages
+  if impl(ghc >= 9.0)
+    ghc-options:       -Winvalid-haddock
+  if impl(ghc >= 9.2)
+    ghc-options:       -Wredundant-bang-patterns
+                       -Woperator-whitespace
 
   default-language:    Haskell2010
   default-extensions:  ConstraintKinds


### PR DESCRIPTION
GHC 9.2.1 added 6 (!!!) new warnings ⚠️ 
4 of them are enabled either by default or with `-Wall`. So I added the remaining two (as they make sense to me)

Here are links to them for convenience of reading:

* https://downloads.haskell.org/ghc/latest/docs/html/users_guide/using-warnings.html#ghc-flag--Wredundant-bang-patterns
* https://downloads.haskell.org/ghc/latest/docs/html/users_guide/using-warnings.html#ghc-flag--Woperator-whitespace