### PR TITLE
Add WithSeverity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 `co-log-core` uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
+## Unreleased
+
+* Added `WithSeverity` to `Colog.Severity`.
+
 ## 🎃 0.3.0.0 — Oct 29, 2021
 
 * [#223](https://github.com/co-log/co-log/pull/223):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The change log is available [on GitHub][2].
 
 ## Unreleased
 
-* Added `WithSeverity` to `Colog.Severity`.
+* Added `WithSeverity` and `mapSeverity` to `Colog.Severity`.
 
 ## 🎃 0.3.0.0 — Oct 29, 2021
 

--- a/co-log-core.cabal
+++ b/co-log-core.cabal
@@ -66,6 +66,8 @@ common common-options
 
   default-language:    Haskell2010
   default-extensions:  ConstraintKinds
+                       DeriveFunctor
+                       DeriveTraversable
                        DeriveGeneric
                        DerivingStrategies
                        GeneralizedNewtypeDeriving

--- a/src/Colog/Core/Severity.hs
+++ b/src/Colog/Core/Severity.hs
@@ -35,6 +35,7 @@ module Colog.Core.Severity
        , pattern E
        , filterBySeverity
        , WithSeverity (..)
+       , mapSeverity
        ) where
 
 import Data.Ix (Ix)
@@ -125,3 +126,14 @@ filterBySeverity' threshold action = filterBySeverity threshold getSeverity acti
 -}
 data WithSeverity msg = WithSeverity { getMsg :: msg , getSeverity :: Severity }
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
+
+{- | Map the given function over the severity of a 'WithSeverity'.
+ 
+This can be useful to operate generically over the severity, for example:
+@
+suppressErrors :: LogAction m (WithSeverity msg) -> LogAction m (WithSeverity msg)
+suppressErrors = cmap (mapSeverity (\s -> if s == Error then Warning else s))
+@
+-}
+mapSeverity :: (Severity -> Severity) -> WithSeverity msg -> WithSeverity msg
+mapSeverity f (WithSeverity msg sev) = WithSeverity msg (f sev)

--- a/src/Colog/Core/Severity.hs
+++ b/src/Colog/Core/Severity.hs
@@ -34,6 +34,7 @@ module Colog.Core.Severity
        , pattern W
        , pattern E
        , filterBySeverity
+       , WithSeverity (..)
        ) where
 
 import Data.Ix (Ix)
@@ -102,3 +103,25 @@ filterBySeverity
     -> LogAction m a
 filterBySeverity s fs = cfilter (\a -> fs a >= s)
 {-# INLINE filterBySeverity #-}
+
+-- Note: the order of the fields here is to allow the constructor to be used infix.
+{-| A message tagged with a 'Severity'.
+ 
+It is common to want to log various types of messages tagged with a severity. 
+'WithSeverity' provides a standard way to do so while allowing the messages to be processed independently of the severity.
+
+It is easy to 'cmap' over a 'LogAction m (WithSeverity a)', or to filter based on the severity.
+
+@
+logSomething :: LogAction m (WithSeverity String) -> m ()
+logSomething logger = logger <& "hello" `WithSeverity` Info
+
+cmap' :: (b -> a) -> LogAction m (WithSeverity a) -> LogAction m (WithSeverity b)
+cmap' f action = cmap (fmap f) action
+
+filterBySeverity' :: (Applicative m) => Severity -> LogAction m (WithSeverity a) -> LogAction m (WithSeverity a)
+filterBySeverity' threshold action = filterBySeverity threshold getSeverity action
+@
+-}
+data WithSeverity msg = WithSeverity { getMsg :: msg , getSeverity :: Severity }
+  deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)


### PR DESCRIPTION
Fixes #13.

Couple of questions:
- I've given it a derived `Show` instance, rather than, say, something like `[DEBUG] <msg>`. I think it's probably better not to get opinionated about formatting and just have a boring `Show`.
- I don't know how you like to name record selectors. I think it's useful to have the selector for severity, as you can see in the example! But I'm happy to call it something else.

I took the liberty of adding a couple of deriving extensions to `default-extensions` since it looked like you had put others there. But happy to just put them in the file.