### PR TITLE
Use ubuntu focal fossa for CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-20.04, macOS-latest, windows-latest]
         cabal: ["3.8"]
         ghc:
           - "8.2.2"


### PR DESCRIPTION
Fixes build. Guess we should wait with 22.04 LTS (Jammy Jellyfish).